### PR TITLE
Make sure first window is in the correct directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -131,7 +131,12 @@ func (c *Config) Exec(debug bool) error {
 			// so only "split window" for subsequent panes
 			if idx != 0 {
 				cc.Add("tmux", "split-window", "-t", winID, "-c", wRoot)
-			}
+			} else {
+                // The wRoot could have been set to something other than the
+                // rootAbs so we should make sure we are in the correct
+                // directory.
+                cc.Add("cd", wRoot)
+            }
 
 			// Execute a pre_window command if one is provided
 			if c.PreWindow != "" {


### PR DESCRIPTION
Thanks for this project, I am so happy to not have to deal with Ruby/Python for this kind of thing. A single binary is great!

Consider this config:

```json
{
  "Name": "test",
  "Root": "~/",
  "Windows": [
    {
      "Name": "editor",
      "Root": "~/j",
      "Layout": "main-vertical",
      "Panes": [
          "ls"
      ]
    }
  ]
}
```

`gmux -d test` will output

```json
2017/05/13 17:48:29 debug: executing: tmux start-server
2017/05/13 17:48:29 debug: executing: tmux new-session -d -s test -n editor
2017/05/13 17:48:29 debug: executing: tmux send-keys -t test:0.0 ls Enter
2017/05/13 17:48:29 debug: executing: tmux select-layout -t test:0 main-vertical
2017/05/13 17:48:29 debug: executing: tmux select-window -t test:0
2017/05/13 17:48:29 debug: executing: tmux select-pane -t test:0.0
```

Note that `ls` is run prior to switching directories to the correct window root. Instead the window will remain in the session root. 

I think this patch will fix the bug but I can't get go to actually compile this project so you will want to verify that it works.

It fails with this:

```
$ echo $GOPATH
/Users/nzac/go

$ go build
# _/Users/nzac/j/oss/gmux
./gmux.go:38: cannot use "github.com/davinche/gmux/cli".BashCompleteList (type func(*"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context)) as type "github.com/urfave/cli".BashCompleteFunc in field value
./gmux.go:46: cannot use "github.com/davinche/gmux/cli".BashCompleteList (type func(*"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context)) as type "github.com/urfave/cli".BashCompleteFunc in field value
./gmux.go:53: cannot use "github.com/davinche/gmux/cli".BashCompleteList (type func(*"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context)) as type "github.com/urfave/cli".BashCompleteFunc in field value
./gmux.go:61: cannot use "github.com/davinche/gmux/cli".BashCompleteList (type func(*"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context)) as type "github.com/urfave/cli".BashCompleteFunc in field value
./gmux.go:75: cannot use c (type *"github.com/urfave/cli".Context) as type *"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context in argument to "github.com/davinche/gmux/cli".Start
./gmux.go:77: cannot use c (type *"github.com/urfave/cli".Context) as type *"github.com/davinche/gmux/vendor/github.com/urfave/cli".Context in argument to "github.com/davinche/gmux/cli".ShowHelp
```