### PR TITLE
docs(readme):gmux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Another Tmux Manager... but in Golang
 ### Go
 
 ~~~
-go get github.com/davinche/gmux
+go get github.com/davinche/gmux # Go version <= 16
+
+go install github.com/davinche/gmux@latest # Go version >= 17
 ~~~
 
 ### Mac


### PR DESCRIPTION
After Go version 17 you no longer can use the go get outside of a module

https://go.dev/doc/go-get-install-deprecation

![image](https://github.com/davinche/gmux/assets/92201792/3a18a122-4302-466f-98b5-ee9b6f691d5c)
