### PR TITLE
Multiple commands per pane.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,24 +80,32 @@ This will create a new file in `$HOME/.gmux/<name>`.
 
 #### Root Level ####
 
-| Name          | Type      | Description                                        |
-|:--------------|:----------|:---------------------------------------------------|
-| Name          | string    | The name of your tmux session                      |
-| Root          | string    | The working directory for your tmux session        |
-| PreWindow     | string    | A command you want run at the start of each window |
-| StartupWindow | string    | The window to focus on after session creation      |
-| StartupPane   | number    | The pane to focus on (starts from 0)               |
-| Windows       | []Windows | An array of configurations for each window         |
+| Name          | Type     | Description                                        |
+|:--------------|:---------|:---------------------------------------------------|
+| Name          | string   | The name of your tmux session                      |
+| Root          | string   | The working directory for your tmux session        |
+| PreWindow     | string   | A command you want run at the start of each window |
+| StartupWindow | string   | The window to focus on after session creation      |
+| StartupPane   | number   | The pane to focus on (starts from 0)               |
+| Windows       | []Window | An array of configurations for each window         |
 
 
 #### Window Object ####
 
-| Name   | Type     | Desc                                          |
-|:-------|:---------|:----------------------------------------------|
-| Name   | string   | The name of the window                        |
-| Root   | string   | The working directory for your window         |
-| Layout | string   | The way you want the panes to be laid out     |
-| Panes  | []string | List of commands you want to run in each pane |
+| Name   | Type   | Desc                                          |
+|:-------|:-------|:----------------------------------------------|
+| Name   | string | The name of the window                        |
+| Root   | string | The working directory for your window         |
+| Layout | string | The way you want the panes to be laid out     |
+| Panes  | []Pane | An array of configurations for each pane      |
+
+
+#### Pane Object ####
+
+| Name      | Type     | Desc                                          |
+|:----------|:---------|:----------------------------------------------|
+| Name      | string   | The name of the pane                          |
+| Commands  | []string | List of commands you want to run in each pane |
 
 
 ## About

--- a/config/config.go
+++ b/config/config.go
@@ -79,9 +79,15 @@ type Config struct {
 // Window represents the configration for a tmux window
 type Window struct {
 	Name   string
-	Layout string   `json:",omitempty"`
-	Root   string   `json:",omitempty"`
-	Panes  []string `json:",omitempty"`
+	Layout string  `json:",omitempty"`
+	Root   string  `json:",omitempty"`
+	Panes  []*Pane `json:",omitempty"`
+}
+
+// Pane represents the configration for a tmux pane
+type Pane struct {
+	Name     string
+	Commands []string `json:",omitempty"`
 }
 
 // Config Methods -------------------------------------------------------------
@@ -143,9 +149,12 @@ func (c *Config) Exec(debug bool) error {
 				cc.Add("tmux", "send-keys", "-t", paneID, c.PreWindow, "Enter")
 			}
 
-			// execute the command for a particular pane if it is provided
-			if p != "" {
-				cc.Add("tmux", "send-keys", "-t", paneID, p, "Enter")
+			for _, cmd := range p.Commands {
+				// execute the command for a particular pane if it is provided
+				if cmd != "" {
+					cc.Add("tmux", "send-keys", "-t", paneID, cmd, "Enter")
+				}
+
 			}
 		}
 
@@ -205,22 +214,37 @@ func New(configName string) *Config {
 	config.Windows[0] = &Window{
 		Name:   "editor",
 		Layout: "main-vertical",
-		Panes: []string{
+		Panes:  make([]*Pane, 1),
+	}
+
+	config.Windows[0].Panes[0] = &Pane{
+		Name: "vim",
+		Commands: []string{
 			"vim",
 			"guard",
 		},
 	}
 
 	config.Windows[1] = &Window{
-		Name: "server",
-		Panes: []string{
+		Name:  "server",
+		Panes: make([]*Pane, 1),
+	}
+
+	config.Windows[1].Panes[0] = &Pane{
+		Name: "rails",
+		Commands: []string{
 			"bundle exec rails s",
 		},
 	}
 
 	config.Windows[2] = &Window{
-		Name: "logs",
-		Panes: []string{
+		Name:  "logs",
+		Panes: make([]*Pane, 1),
+	}
+
+	config.Windows[2].Panes[0] = &Pane{
+		Name: "tail",
+		Commands: []string{
 			"tail -f log/development.log",
 		},
 	}


### PR DESCRIPTION
If I have a project structured like this:
```
proj_root/
-- frontend/
-- database/
-- mailserver/
```

If I want to open multiple services in a window, each in their own pane, I need to chain commands together with `&&` like:
- `cd database && ./run-db`
- `cd mailserver && ./run-mail`

That works, but if I later want to go to that pane and restart the service, I need to manually remove the `cd` from the command, which is a pain (sorry pun intended :roll_eyes:). See this example: https://youtu.be/1QwrEaA2YUM?si=R9kz5akUWHbgiO_I&t=765

Allowing each pane to execute multiple commands seemed like the easiest way around this, so that's why I've made this PR. If there's an existing solution I'm not thinking of, please let me know! Thanks!